### PR TITLE
Add constants for bank and business information, enhance PDF receipt

### DIFF
--- a/src/Receipts/PDFReceipt.tsx
+++ b/src/Receipts/PDFReceipt.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react'
 import dayjs from 'dayjs'
 import kyunLogo from '../Vouchers/assets/kyunkyun-logo.jpg'
 import bankLogo from './assets/bank_logo.jpeg'
+import { BANK_DETAILS, BUSINESS_INFO } from './const'
 
 const PADDING_VALUE = 24
 
@@ -193,10 +194,8 @@ export default function PDFReceipt({
           <Text style={{ color: 'grey', marginBottom: '1rem' }}>
             Relevé d'Identité Bancarie
           </Text>
-          <Text style={{ fontWeight: 'bold' }}>BE IN MAGHREB</Text>
-          <Text>DAR AL MOUKAWIL</Text>
-          <Text>MARRAKECH KOUTOUBIA</Text>
-          <Text>PLACE JAMAA LAFNA, MEDINA MARRAKECH</Text>
+          <Text style={{ fontWeight: 'bold' }}>{BUSINESS_INFO.name}</Text>
+          <Text>{BANK_DETAILS.agency}</Text>
 
           <Text style={{ color: 'grey', marginBottom: '1rem' }}>
             Références Bancaires
@@ -245,22 +244,22 @@ export default function PDFReceipt({
               <Text
                 style={[styles.bankCell, styles.bankCellBody, { width: '20%' }]}
               >
-                XXX
+                {BANK_DETAILS.bankCode}
               </Text>
               <Text
                 style={[styles.bankCell, styles.bankCellBody, { width: '20%' }]}
               >
-                XXX
+                {BANK_DETAILS.villeCode}
               </Text>
               <Text
                 style={[styles.bankCell, styles.bankCellBody, { width: '40%' }]}
               >
-                XXXXXXXXXXXXXXXX
+                {BANK_DETAILS.ccNumber}
               </Text>
               <Text
                 style={[styles.bankCell, styles.bankCellBody, { width: '20%' }]}
               >
-                XX
+                {BANK_DETAILS.rib}
               </Text>
             </View>
             <View style={styles.row}>
@@ -270,7 +269,7 @@ export default function PDFReceipt({
                   { width: '100%', paddingLeft: '2rem' },
                 ]}
               >
-                CODE SWIFT: BCMAMAMC
+                CODE SWIFT: {BANK_DETAILS.swift}
               </Text>
             </View>
           </View>
@@ -322,17 +321,14 @@ export default function PDFReceipt({
         {/* FOOTER */}
         <View style={styles.footer}>
           <Text style={[styles.footerText, { fontSize: 8 }]}>
-            BE IN MAGHREB / ICE: 003351299000019
+            {BUSINESS_INFO.name} / ICE: {BUSINESS_INFO.ice}
           </Text>
+          <Text style={styles.footerText}>{BUSINESS_INFO.address}</Text>
           <Text style={styles.footerText}>
-            RUE Atlas IMM 45, 4ème ETAGE N° 16 MAARIF CASABLANCA, MOROCCO
+            Mobile 1: {BUSINESS_INFO.mobile_1} Mobile 2:{' '}
+            {BUSINESS_INFO.mobile_2}
           </Text>
-          <Text style={styles.footerText}>
-            Fix: +212 524 370 643 Mobile 1: +212661828251 Mobile 2: +21661685568
-          </Text>
-          <Text style={styles.footerText}>
-            Office: contact@beinmorocco.net website: WEBSITE
-          </Text>
+          <Text style={styles.footerText}>Office: {BUSINESS_INFO.email}</Text>
         </View>
       </Page>
     </Document>

--- a/src/Receipts/PDFReceipt.tsx
+++ b/src/Receipts/PDFReceipt.tsx
@@ -293,14 +293,16 @@ export default function PDFReceipt({
                 style: 'currency',
                 currency: 'EUR',
                 currencyDisplay: 'code',
-              }).format(paymentDetails.advance.amount)}
+              }).format(data.tour.split ? paymentDetails.advance.amount : 0)}
             </Text>
             <Text style={[styles.cell, { width: '50%' }]}>
               {Intl.NumberFormat('it-IT', {
                 style: 'currency',
                 currency: 'EUR',
                 currencyDisplay: 'code',
-              }).format(paymentDetails.final.amount)}
+              }).format(
+                data.tour.split ? paymentDetails.final.amount : data.tour.amount
+              )}
             </Text>
           </View>
         </View>
@@ -328,7 +330,7 @@ export default function PDFReceipt({
             Mobile 1: {BUSINESS_INFO.mobile_1} Mobile 2:{' '}
             {BUSINESS_INFO.mobile_2}
           </Text>
-          <Text style={styles.footerText}>Office: {BUSINESS_INFO.email}</Text>
+          <Text style={styles.footerText}>E-mail: {BUSINESS_INFO.email}</Text>
         </View>
       </Page>
     </Document>

--- a/src/Receipts/const.ts
+++ b/src/Receipts/const.ts
@@ -1,0 +1,18 @@
+export const BANK_DETAILS = Object.freeze({
+  agency: 'CENTRE ENTREPRISES FES',
+  swift: 'BCMAMAMC',
+  bankCode: '007',
+  villeCode: '270',
+  ccNumber: '0000568000005096',
+  rib: '68',
+})
+
+export const BUSINESS_INFO = Object.freeze({
+  name: 'KYUN KYUN MOROCCO TOURS',
+  ice: '003961938000050',
+  address:
+    'Résidence ICHRAK CENTRE, Imm 30, 1er étage, Bureau 8, Lisasfa, Casablanca',
+  mobile_1: '+39 366 729 0133',
+  mobile_2: '+212 700 392 665',
+  email: 'info@kyunkyunmoroccotours.com',
+})

--- a/src/Receipts/index.tsx
+++ b/src/Receipts/index.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   Box,
   Button,
+  Checkbox,
   FileInput,
   Flex,
   Grid,
@@ -44,6 +45,7 @@ const schema: yup.ObjectSchema<ReceiptFormValues> = yup.object().shape({
       .typeError('Il costo deve essere un numero')
       .required('Inserisci il costo del viaggio')
       .min(0, 'Il costo non può essere negativo'),
+    split: yup.boolean(),
   }),
 })
 
@@ -62,6 +64,7 @@ export default function Receipts() {
       tour: {
         type: 'standard',
         amount: 10200,
+        split: true,
       },
     },
     resolver: yupResolver(schema),
@@ -231,6 +234,20 @@ export default function Receipts() {
                       leftSection={<IconCurrencyEuro />}
                       min={0}
                       error={error?.message}
+                    />
+                  )}
+                />
+              </Grid.Col>
+              <Grid.Col>
+                <Controller
+                  control={control}
+                  name="tour.split"
+                  render={({ field }) => (
+                    <Checkbox
+                      checked={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                      label="Dividi spesa (acconto e saldo)"
                     />
                   )}
                 />

--- a/src/Receipts/types.ts
+++ b/src/Receipts/types.ts
@@ -7,5 +7,6 @@ export type ReceiptFormValues = {
   tour: {
     type: TourType
     amount: number
+    split?: boolean
   }
 }

--- a/src/Vouchers/PDFVoucher.tsx
+++ b/src/Vouchers/PDFVoucher.tsx
@@ -12,6 +12,7 @@ import sivolaLogo from './assets/sivola-logo.jpg'
 import { writeRoomDistribution } from './utils'
 import { emergencyContacts } from './data'
 import dayjs from 'dayjs'
+import { BUSINESS_INFO } from '../Receipts/const'
 
 const PADDING_VALUE = 24
 
@@ -59,13 +60,7 @@ const styles = StyleSheet.create({
   },
 })
 
-function TourTable({
-  t,
-  coupon,
-}: {
-  t: FormValues['tour'][number]
-  coupon: string
-}) {
+function TourTable({ t }: { t: FormValues['tour'][number] }) {
   return (
     <>
       <View style={styles.table}>
@@ -97,10 +92,6 @@ function TourTable({
           <Text style={[styles.cell, styles.col2]}>
             {writeRoomDistribution(t.hotel.rooms)}
           </Text>
-        </View>
-        <View style={[styles.row, { borderBottom: '1px solid #EEEEEE' }]}>
-          <Text style={[styles.cell, styles.col1]}>CODICE PRENOTAZIONE</Text>
-          <Text style={[styles.cell, styles.col2]}>{coupon}</Text>
         </View>
         <View style={styles.row}>
           <Text style={[styles.cell, styles.col1]}>TRATTAMENTO</Text>
@@ -153,6 +144,7 @@ function PDFVoucher({ data }: { data: FormValues }) {
             </Text>
           ))}
         </View>
+
         {/* LOGHI */}
         <View style={styles.row}>
           <Image src={kyunLogo} style={{ width: 120 }} />
@@ -160,17 +152,20 @@ function PDFVoucher({ data }: { data: FormValues }) {
         <View style={{ margin: '20 auto 5 auto' }}>
           <Image src={sivolaLogo} style={{ width: 100 }} />
         </View>
+
         {/* HEADER */}
         <Text style={styles.header}>
-          {`${data.dates.from.toLocaleDateString('it-IT')} - ${data.dates.to.toLocaleDateString('it-IT')} — ${data.numPax} PAX`}
+          {`${data.dates.from.toLocaleDateString('it-IT')} - ${data.dates.to.toLocaleDateString('it-IT')} — ${data.numPax - 2} PAX + 1 TL`}
         </Text>
+
         {/* TOUR LEADER */}
-        <Text style={styles.sectionTitle}>TOUR LEADER</Text>
-        <Text>{data.tourLeader.name}</Text>
+        <Text style={styles.sectionTitle}>CODICE PRENOTAZIONE</Text>
+        <Text>{data.coupon}</Text>
+
         {/* TOUR TABLES */}
         {data.tour.map((t, i) => (
           <View key={i} style={{ marginTop: 10 }} wrap={false}>
-            <TourTable t={t} coupon={data.coupon} />
+            <TourTable t={t} />
           </View>
         ))}
 
@@ -190,10 +185,11 @@ function PDFVoucher({ data }: { data: FormValues }) {
           fixed
         >
           <Text style={{ textAlign: 'center', fontSize: 8 }}>
-            Kyun Kyun Morocco Tour -{' '}
+            {BUSINESS_INFO.name} -{' '}
             <Text style={{ fontStyle: 'italic' }}>
               Voucher {dayjs(data.dates.from).format('DD/MM/YYYY')}-
-              {dayjs(data.dates.to).format('DD/MM/YYYY')} ({data.numPax} PAX)
+              {dayjs(data.dates.to).format('DD/MM/YYYY')} ({data.numPax - 2} PAX
+              + 1 TL)
             </Text>
           </Text>
           <Text

--- a/src/Vouchers/index.tsx
+++ b/src/Vouchers/index.tsx
@@ -182,7 +182,7 @@ function Vouchers() {
               {...form.getInputProps('numPax')}
             />
           </Grid.Col>
-          <Grid.Col>
+          {/* <Grid.Col>
             <Title order={4}>Tour Leader</Title>
           </Grid.Col>
           <Grid.Col span={6}>
@@ -191,7 +191,7 @@ function Vouchers() {
               {...form.getInputProps('tourLeader.name')}
             />
           </Grid.Col>
-          <Grid.Col span={6} />
+          <Grid.Col span={6} /> */}
           <Grid.Col>
             <Title order={3}>Tappe</Title>
           </Grid.Col>


### PR DESCRIPTION
Introduce constants for bank and business information to streamline PDF receipt generation. Implement a split option for tour expenses and improve the formatting of the PDF receipt for better readability and structure.